### PR TITLE
Upgrade terraform-provider-cloudamqp to v1.24.1

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 
 require (
-	github.com/cloudamqp/terraform-provider-cloudamqp v1.24.0
+	github.com/cloudamqp/terraform-provider-cloudamqp v1.24.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.42.1
 	github.com/pulumi/pulumi/sdk/v3 v3.56.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -509,8 +509,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudamqp/terraform-provider-cloudamqp v1.24.0 h1:VkLTC2Lf0v65uT8+wIbaaAQrMiNj56/ilDDS9lbpyDU=
-github.com/cloudamqp/terraform-provider-cloudamqp v1.24.0/go.mod h1:+lBvWUTY7edpKcSmH4ktLHP1Ah5Jbqcpuq/nKTQA/a4=
+github.com/cloudamqp/terraform-provider-cloudamqp v1.24.1 h1:eAnU/zjuaDNJ2rbpR8ABFf/e2ZRcTMlpELbUGFi3u3U=
+github.com/cloudamqp/terraform-provider-cloudamqp v1.24.1/go.mod h1:+lBvWUTY7edpKcSmH4ktLHP1Ah5Jbqcpuq/nKTQA/a4=
 github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider --kind=provider pulumi-cloudamqp`.

---

Upgrading upstream provider cloudamqp to 1.24.1.

Fixes #181
