### PR TITLE
Do not skip tests if CLOUDAMQP_APIKEY is unset

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -11,10 +11,6 @@ import (
 
 func getApiKey(t *testing.T) string {
 	name := os.Getenv("CLOUDAMQP_APIKEY")
-	if name == "" {
-		t.Skipf("Skipping test due to missing CLOUDAMQP_APIKEY environment variable")
-	}
-
 	return name
 }
 


### PR DESCRIPTION
What it says on the box. Prevents tests from passing if necessary authentication is missing.
